### PR TITLE
Potential fix for code scanning alert no. 6: Use of `Kernel.open` or `IO.read` or similar sinks with a non-constant value

### DIFF
--- a/app/services/politician_pdf_service.rb
+++ b/app/services/politician_pdf_service.rb
@@ -71,8 +71,9 @@ class PoliticianPdfService
   end
 
   def download_pdf(url)
-    URI.open(url)
-  rescue OpenURI::HTTPError => e
+    uri = URI.parse(url)
+    Net::HTTP.get(uri)
+  rescue StandardError => e
     Rails.logger.error "Failed to download PDF from #{url}: #{e.message}"
     nil
   end


### PR DESCRIPTION
Potential fix for [https://github.com/ikramagix/Confiable/security/code-scanning/6](https://github.com/ikramagix/Confiable/security/code-scanning/6)

To fix the problem, we should replace the use of `URI.open` with a safer alternative that does not call `Kernel.open` internally. The recommended approach is to use an HTTP client to fetch the content from the URL. In this case, we can use the `Net::HTTP` library to perform the HTTP request and retrieve the PDF content.

We will modify the `download_pdf` method to use `Net::HTTP.get` instead of `URI.open`. This change will ensure that the URL is fetched securely without the risk of executing arbitrary code.